### PR TITLE
feat(models): add GPT-5.5 presets and defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ The app currently exposes presets across these providers:
 
 Choose any available preset per phase through the CLI (`agentrules configure --models`) or by editing `config.toml` / `config/agents.py`. At runtime the values populate `MODEL_CONFIG`, which the pipeline consumes while resolving phase architects (`src/agentrules/core/agents/factory/factory.py`).
 
-> **Preset tip:** Legacy-friendly presets stay under the `gpt5-*` keys (backed by the `gpt-5` model name) so existing `config.toml` files continue to work, while the newer GPT‑5.1 presets live under the `gpt51-*` keys, GPT‑5.2 presets under `gpt52-*`, and GPT‑5.4 Mini/Nano variants under the `gpt54-mini-*` and `gpt54-nano-*` keys. Mixing them per phase or per-agent is fully supported.
+> **Preset tip:** Legacy-friendly presets stay under the `gpt5-*` keys (backed by the `gpt-5` model name) so existing `config.toml` files continue to work. Newer GPT‑5.5 presets live under `gpt55-*`, GPT‑5.1 presets under `gpt51-*`, GPT‑5.2 presets under `gpt52-*`, and GPT‑5.4 Mini/Nano variants under the `gpt54-mini-*` and `gpt54-nano-*` keys. Codex selections in the settings UI come from the live app-server catalog rather than this static shorthand list.
 
 ## 🧠 Reasoning & Advanced Configuration
 

--- a/docs/codex-runtime.md
+++ b/docs/codex-runtime.md
@@ -6,7 +6,7 @@ AgentRules supports Codex as a local runtime provider through `codex app-server`
 
 - Launches the local `codex` CLI in app-server mode.
 - Reuses ChatGPT login state from `CODEX_HOME` instead of asking AgentRules for an OpenAI API key.
-- Lets phase presets use `codex-*` model variants such as `codex-gpt-5.3-codex` and `codex-gpt-5.4`.
+- Surfaces live `Codex: <model>` options from app-server `model/list`, while keeping older `codex-*` aliases for compatibility.
 - Keeps structured outputs enabled for the phases that already depend on schemas.
 
 ## Configure it
@@ -73,6 +73,7 @@ Notes:
 - Non-Codex researcher presets still require Tavily unless you are in offline mode
 - Codex-backed Phase 3 agents inspect files from the repository directly instead of receiving embedded file contents
 - `Codex: <model>` options come from live app-server `model/list` output and track runtime model availability directly
+- Model availability is account- and runtime-dependent; current signed-in runtimes commonly expose models such as `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.3-codex`, `gpt-5.3-codex-spark`, and `gpt-5.2`
 
 ## Optional live smoke
 

--- a/src/agentrules/config/agents.py
+++ b/src/agentrules/config/agents.py
@@ -55,6 +55,11 @@ from agentrules.core.types.models import (
     GPT5_4_NANO_MEDIUM,
     GPT5_4_NANO_NONE,
     GPT5_4_NANO_XHIGH,
+    GPT5_5_DEFAULT,
+    GPT5_5_HIGH,
+    GPT5_5_LOW,
+    GPT5_5_NONE,
+    GPT5_5_XHIGH,
     GPT5_DEFAULT,
     GPT5_HIGH,
     GPT5_MINI,
@@ -379,6 +384,36 @@ BASE_MODEL_PRESETS: dict[str, PresetDefinition] = {
         description="Cost-efficient GPT-5 Mini with 400k context and high reasoning.",
         provider=ModelProvider.OPENAI,
     ),
+    "gpt55-none": _preset(
+        config=GPT5_5_NONE,
+        label="GPT-5.5 (no reasoning)",
+        description="GPT-5.5 via Responses API with reasoning disabled and low verbosity for fast runs.",
+        provider=ModelProvider.OPENAI,
+    ),
+    "gpt55-low": _preset(
+        config=GPT5_5_LOW,
+        label="GPT-5.5 (low reasoning)",
+        description="GPT-5.5 via Responses API with low reasoning effort and low verbosity.",
+        provider=ModelProvider.OPENAI,
+    ),
+    "gpt55-default": _preset(
+        config=GPT5_5_DEFAULT,
+        label="GPT-5.5 (medium reasoning)",
+        description="GPT-5.5 via Responses API with medium reasoning and verbosity.",
+        provider=ModelProvider.OPENAI,
+    ),
+    "gpt55-high": _preset(
+        config=GPT5_5_HIGH,
+        label="GPT-5.5 (high reasoning)",
+        description="GPT-5.5 via Responses API with high reasoning depth and high verbosity.",
+        provider=ModelProvider.OPENAI,
+    ),
+    "gpt55-xhigh": _preset(
+        config=GPT5_5_XHIGH,
+        label="GPT-5.5 (xhigh reasoning)",
+        description="GPT-5.5 via Responses API with maximum supported reasoning depth and high verbosity.",
+        provider=ModelProvider.OPENAI,
+    ),
     "gpt5-minimal": _preset(
         config=GPT5_MINIMAL,
         label="GPT-5 (minimal reasoning)",
@@ -583,13 +618,13 @@ MODEL_PRESETS: dict[str, PresetDefinition] = {
 }
 
 MODEL_PRESET_DEFAULTS: dict[str, str] = {
-    "phase1": "gpt5-mini",
-    "phase2": "gpt5-mini",
-    "phase3": "gpt5-mini",
-    "phase4": "gpt5-mini",
-    "phase5": "gpt5-mini",
-    "final": "gpt5-mini",
-    "researcher": "gpt5-mini",
+    "phase1": "gpt55-default",
+    "phase2": "gpt55-default",
+    "phase3": "gpt55-default",
+    "phase4": "gpt55-default",
+    "phase5": "gpt55-default",
+    "final": "gpt55-default",
+    "researcher": "gpt55-default",
 }
 
 

--- a/src/agentrules/core/agents/openai/config.py
+++ b/src/agentrules/core/agents/openai/config.py
@@ -46,6 +46,7 @@ _GPT5_NONE_DEFAULTS = ModelDefaults(
 )
 
 _PREFIX_DEFAULTS: tuple[tuple[str, ModelDefaults], ...] = (
+    ("gpt-5.5", _GPT5_RESPONSES_DEFAULTS),
     ("gpt-5.4-pro", _GPT5_PRO_DEFAULTS),
     ("gpt-5.4", _GPT5_NONE_DEFAULTS),
     ("gpt-5.3-codex", _GPT5_RESPONSES_DEFAULTS),

--- a/src/agentrules/core/agents/openai/request_builder.py
+++ b/src/agentrules/core/agents/openai/request_builder.py
@@ -9,6 +9,8 @@ from agentrules.core.agents.base import ReasoningMode
 ApiType = Literal["responses", "chat"]
 
 _GPT5_RESPONSES_REASONING_SUPPORT: tuple[tuple[str, frozenset[str]], ...] = (
+    ("gpt-5.5-pro", frozenset()),
+    ("gpt-5.5", frozenset({"none", "low", "medium", "high", "xhigh"})),
     ("gpt-5.4-pro", frozenset({"medium", "high", "xhigh"})),
     ("gpt-5.4", frozenset({"none", "low", "medium", "high", "xhigh"})),
     ("gpt-5.3-codex", frozenset({"low", "medium", "high", "xhigh"})),

--- a/src/agentrules/core/types/models.py
+++ b/src/agentrules/core/types/models.py
@@ -372,6 +372,37 @@ GPT5_MINI = _gpt5_responses_model(
     text_verbosity="medium",
 )
 
+# GPT-5.5 configurations
+GPT5_5_NONE = _gpt5_responses_model(
+    "gpt-5.5",
+    reasoning=ReasoningMode.DISABLED,
+    text_verbosity="low",
+)
+
+GPT5_5_LOW = _gpt5_responses_model(
+    "gpt-5.5",
+    reasoning=ReasoningMode.LOW,
+    text_verbosity="low",
+)
+
+GPT5_5_DEFAULT = _gpt5_responses_model(
+    "gpt-5.5",
+    reasoning=ReasoningMode.MEDIUM,
+    text_verbosity="medium",
+)
+
+GPT5_5_HIGH = _gpt5_responses_model(
+    "gpt-5.5",
+    reasoning=ReasoningMode.HIGH,
+    text_verbosity="high",
+)
+
+GPT5_5_XHIGH = _gpt5_responses_model(
+    "gpt-5.5",
+    reasoning=ReasoningMode.XHIGH,
+    text_verbosity="high",
+)
+
 # GPT-5.1 configurations
 GPT5_1_DEFAULT = _gpt5_responses_model(
     "gpt-5.1",

--- a/tests/test_openai_responses.py
+++ b/tests/test_openai_responses.py
@@ -68,6 +68,20 @@ class OpenAIResponsesTests(unittest.TestCase):
         self.assertEqual(params.get("reasoning"), {"effort": "medium"})
         self.assertEqual(params.get("text"), {"verbosity": "medium"})
 
+    def test_prepare_request_uses_responses_api_for_gpt55(self) -> None:
+        architect = OpenAIArchitect(
+            model_name="gpt-5.5",
+            reasoning=ReasoningMode.XHIGH,
+            text_verbosity="high"
+        )
+        prepared = architect._prepare_request("Hej")
+        params = prepared.payload
+
+        self.assertEqual(prepared.api, "responses")
+        self.assertEqual(params["model"], "gpt-5.5")
+        self.assertEqual(params.get("reasoning"), {"effort": "xhigh"})
+        self.assertEqual(params.get("text"), {"verbosity": "high"})
+
     def test_prepare_request_uses_responses_api_for_gpt54_snapshot(self) -> None:
         architect = OpenAIArchitect(
             model_name="gpt-5.4-2026-03-05",

--- a/tests/unit/agents/test_openai_helpers.py
+++ b/tests/unit/agents/test_openai_helpers.py
@@ -17,6 +17,12 @@ class OpenAIConfigTests(unittest.TestCase):
         self.assertTrue(defaults.use_responses_api)
         self.assertIsNone(defaults.default_temperature)
 
+    def test_resolve_defaults_for_gpt55_prefix(self) -> None:
+        defaults = resolve_model_defaults("gpt-5.5")
+        self.assertEqual(defaults.default_reasoning, ReasoningMode.MEDIUM)
+        self.assertTrue(defaults.use_responses_api)
+        self.assertIsNone(defaults.default_temperature)
+
     def test_resolve_defaults_for_gpt51_prefix(self) -> None:
         defaults = resolve_model_defaults("gpt-5.1-large")
         self.assertEqual(defaults.default_reasoning, ReasoningMode.DISABLED)
@@ -174,6 +180,41 @@ class OpenAIRequestBuilderTests(unittest.TestCase):
         self.assertEqual(payload["input"], "Hello gpt-5.3-codex")
         self.assertEqual(payload["reasoning"], {"effort": "medium"})
         self.assertEqual(payload["text"], {"verbosity": "medium"})
+
+    def test_prepare_request_for_responses_api_gpt55_xhigh(self) -> None:
+        prepared = prepare_request(
+            model_name="gpt-5.5",
+            content="Hello gpt-5.5",
+            reasoning=ReasoningMode.XHIGH,
+            temperature=None,
+            tools=None,
+            text_verbosity="high",
+            use_responses_api=True,
+        )
+
+        self.assertEqual(prepared.api, "responses")
+        payload = prepared.payload
+        self.assertEqual(payload["model"], "gpt-5.5")
+        self.assertEqual(payload["input"], "Hello gpt-5.5")
+        self.assertEqual(payload["reasoning"], {"effort": "xhigh"})
+        self.assertEqual(payload["text"], {"verbosity": "high"})
+
+    def test_prepare_request_for_responses_api_gpt55_minimal_downgrades_to_none(self) -> None:
+        prepared = prepare_request(
+            model_name="gpt-5.5",
+            content="Hello gpt-5.5",
+            reasoning=ReasoningMode.MINIMAL,
+            temperature=None,
+            tools=None,
+            text_verbosity="low",
+            use_responses_api=True,
+        )
+
+        self.assertEqual(prepared.api, "responses")
+        payload = prepared.payload
+        self.assertEqual(payload["model"], "gpt-5.5")
+        self.assertEqual(payload["reasoning"], {"effort": "none"})
+        self.assertEqual(payload["text"], {"verbosity": "low"})
 
     def test_prepare_request_for_responses_api_gpt54_mini_none(self) -> None:
         prepared = prepare_request(

--- a/tests/unit/test_model_overrides.py
+++ b/tests/unit/test_model_overrides.py
@@ -58,6 +58,10 @@ class ModelOverrideTestCase(unittest.TestCase):
         self.model_config.apply_user_overrides()
         self.assertEqual(self.agents_module.MODEL_CONFIG["phase1"], default_config)
 
+    def test_default_phase_presets_use_gpt55_default(self) -> None:
+        self.assertTrue(self.agents_module.MODEL_PRESET_DEFAULTS)
+        self.assertTrue(all(value == "gpt55-default" for value in self.agents_module.MODEL_PRESET_DEFAULTS.values()))
+
     def test_apply_user_overrides_accepts_dynamic_codex_runtime_model(self) -> None:
         runtime_model_key = self.model_config.make_codex_runtime_preset_key("gpt-6-codex-preview")
 
@@ -180,6 +184,9 @@ class ModelOverrideTestCase(unittest.TestCase):
         self.assertEqual(selection.reasoning_effort, "xhigh")
 
     def test_openai_registry_includes_new_gpt5_codex_and_snapshot_presets(self) -> None:
+        self.assertIn("gpt55-none", self.agents_module.MODEL_PRESETS)
+        self.assertIn("gpt55-default", self.agents_module.MODEL_PRESETS)
+        self.assertIn("gpt55-xhigh", self.agents_module.MODEL_PRESETS)
         self.assertIn("gpt-5.2-codex", self.agents_module.MODEL_PRESETS)
         self.assertIn("gpt-5.3-codex", self.agents_module.MODEL_PRESETS)
         self.assertIn("gpt-5.4-2026-03-05", self.agents_module.MODEL_PRESETS)


### PR DESCRIPTION
## Summary
- add `gpt-5.5` model definitions and `gpt55-*` OpenAI presets
- switch all phase defaults from `gpt5-mini` to `gpt55-default`
- handle GPT-5.5 explicitly in OpenAI default resolution and reasoning-effort request building
- clarify in docs that Codex model options are discovered live from the app-server catalog
- add regression coverage for the new presets and default mappings

## Context / Why
The repo was missing the latest GPT-5.5 mainline model support. This refresh keeps the OpenAI preset catalog current, preserves the existing Codex app-server discovery model, and moves the default phase baseline from `gpt5-mini` to `gpt55-default`.

## Changes
- add `GPT5_5_*` model configs and `gpt55-*` preset aliases in the OpenAI model registry
- update OpenAI request/default handling so `gpt-5.5` uses explicit reasoning-effort support instead of falling through to legacy GPT-5 behavior
- change every phase default, including `researcher`, from `gpt5-mini` to `gpt55-default`
- update Codex runtime docs and README guidance to reflect live-discovered Codex model choices
- add and extend tests covering GPT-5.5 presets, helper behavior, response payloads, and phase default mappings

## How to Test
1. `PYTHONPATH=src ./.venv/bin/pytest tests/test_openai_responses.py tests/unit/agents/test_openai_helpers.py tests/unit/test_model_overrides.py -q`
2. `./.venv/bin/ruff check src/agentrules/core/types/models.py src/agentrules/config/agents.py src/agentrules/core/agents/openai/request_builder.py src/agentrules/core/agents/openai/config.py tests/test_openai_responses.py tests/unit/agents/test_openai_helpers.py tests/unit/test_model_overrides.py`
3. `PYTHONPATH=src ./.venv/bin/python -c "import agentrules"`

## Rollout / Backout
- No migrations or feature flags are required.
- Primary rollout impact: phase runs now default to `gpt55-default` instead of `gpt5-mini`.
- Backout is a straight revert of commit `1ecf656`.

## Risks / Notes
- This intentionally stays scoped to the current model-refresh work.
- `gpt-5.5-pro`, `gpt-5.4-pro`, and `gpt-5-nano` are left out of scope for now.
- The main user-visible behavior change is the default phase model shift to GPT-5.5 medium reasoning.

## Checklist
- [x] Focused scope limited to the current model-refresh work
- [x] Targeted pytest coverage passed
- [x] Ruff checks passed
- [x] Import smoke test passed
