### PR TITLE
ci(release): keep uv lock synchronized

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,6 +19,7 @@ jobs:
   release-please:
     name: Open Release PR / Publish Release
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Run release-please
         id: release
@@ -27,3 +28,55 @@ jobs:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
           config-file: .release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      - name: Resolve release PR branch
+        if: steps.release.outputs.prs_created == 'true'
+        id: release-pr
+        env:
+          RELEASE_PR: ${{ steps.release.outputs.pr }}
+        run: |
+          branch=$(python -c 'import json, os; print(json.loads(os.environ["RELEASE_PR"])["headBranchName"])')
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+
+      - name: Check out release PR branch
+        if: steps.release.outputs.prs_created == 'true'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ steps.release-pr.outputs.branch }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Install uv
+        if: steps.release.outputs.prs_created == 'true'
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          enable-cache: false
+          version: "0.9.17"
+
+      - name: Regenerate release lockfile
+        if: steps.release.outputs.prs_created == 'true'
+        run: |
+          uv lock
+          uv lock --check
+
+          if ! git diff --quiet -- . ':(exclude)uv.lock'; then
+            echo "uv lock changed tracked files other than uv.lock:" >&2
+            git diff --name-only -- . ':(exclude)uv.lock' >&2
+            exit 1
+          fi
+
+      - name: Commit release lockfile
+        if: steps.release.outputs.prs_created == 'true'
+        env:
+          RELEASE_BRANCH: ${{ steps.release-pr.outputs.branch }}
+        run: |
+          if git diff --quiet -- uv.lock; then
+            echo "uv.lock is already current."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add uv.lock
+          git commit -m "chore(release): refresh uv lock"
+          git push origin "HEAD:$RELEASE_BRANCH"

--- a/.github/workflows/validate-uv-lock.yml
+++ b/.github/workflows/validate-uv-lock.yml
@@ -1,0 +1,29 @@
+name: Validate uv Lockfile
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/validate-uv-lock.yml"
+      - "pyproject.toml"
+      - "uv.lock"
+
+permissions:
+  contents: read
+
+jobs:
+  validate-uv-lock:
+    name: Verify pyproject and uv.lock agree
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          enable-cache: false
+          version: "0.9.17"
+
+      - name: Validate lockfile
+        run: uv lock --check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,6 +158,7 @@ It is 2026 and you are developing using Python 3.11+ with modern provider SDKs (
 # Tests & CI
 - Required minimal CI jobs described in Imperative Directives.
 - Add unit tests for all P0/P1 changes. Benchmarks must be lightweight for CI (sample N=100).
+- Release Please owns project version bumps. Its workflow must regenerate and commit `uv.lock` on the release PR branch, and pull-request CI must enforce `uv lock --check` whenever `pyproject.toml` or `uv.lock` changes.
 
 # Security & Logging
 - Redact sensitive fields in logs: environment variables and provider responses that contain `api_key`, `Authorization`, etc.

--- a/README.md
+++ b/README.md
@@ -364,6 +364,7 @@ Toggle outputs with `agentrules configure --outputs` or via the config TOML.
 - Deterministic smoke runs (CI/local without API calls): `agentrules analyze --offline tests/tests_input`
 - Full suite: `pytest`
 - Releases are Release Please-driven: merges to `main` update/open a release PR, and merging that PR creates the `vX.Y.Z` tag + GitHub release automatically.
+- Release Please PRs regenerate and commit `uv.lock` automatically; pull requests that change project or lock metadata must pass `uv lock --check`.
 - GitHub Actions publishes package artifacts with Trusted Publishing (OIDC) via `.github/workflows/publish-pypi.yml` (no long-lived PyPI API token).
 - Run a safe preflight publish first from Actions with `workflow_dispatch` and `repository = testpypi`; publish to production PyPI on release-tag push or manual `repository = pypi`.
 - Keep docs and presets in sync when adding providers (`config/agents.py`, `config/tools.py`, `core/agents/*`).
@@ -373,10 +374,12 @@ Toggle outputs with `agentrules configure --outputs` or via the config TOML.
 1. Merge feature PRs into `main` using Conventional Commit-style titles/messages (for example `feat: ...`, `fix: ...`).
    For an intentional one-release version override, include a `Release-As: X.Y.Z` footer in a commit merged to `main`; do not manually edit `pyproject.toml` or `.release-please-manifest.json`.
 2. `.github/workflows/release-please.yml` updates or opens a release PR with the version bump and changelog.
-3. (Optional, recommended) run `.github/workflows/publish-pypi.yml` manually with `repository = testpypi` from the release PR head commit.
-4. Merge the release PR. Release Please creates/pushes the matching `vX.Y.Z` tag and publishes a GitHub release.
-5. The tag push triggers `.github/workflows/publish-pypi.yml` to publish to production PyPI.
-6. One-time setup for new projects:
+3. The release workflow regenerates `uv.lock` on the release PR branch and commits it when project metadata changed.
+4. Confirm the release PR passes the `Verify pyproject and uv.lock agree` check.
+5. (Optional, recommended) run `.github/workflows/publish-pypi.yml` manually with `repository = testpypi` from the release PR head commit.
+6. Merge the release PR. Release Please creates/pushes the matching `vX.Y.Z` tag and publishes a GitHub release.
+7. The tag push triggers `.github/workflows/publish-pypi.yml` to publish to production PyPI.
+8. One-time setup for new projects:
    - Configure a repo secret `RELEASE_PLEASE_TOKEN` (PAT or GitHub App token) with permission to create/update PRs, tags, and releases. This ensures tag pushes from Release Please trigger downstream workflows.
    - Configure Trusted Publishers on TestPyPI and PyPI for repository `trevor-nichols/agentrules-architect`, workflow `.github/workflows/publish-pypi.yml`, and environments `testpypi`/`pypi`.
 


### PR DESCRIPTION
## Summary

- Regenerate `uv.lock` automatically whenever Release Please creates or updates a release PR.
- Commit the regenerated lockfile back to the release PR branch using the existing release token.
- Add a read-only PR check that rejects stale `pyproject.toml`/`uv.lock` combinations.
- Document the automated release invariant and updated operator workflow.

## Context / Why

Release Please updates the project version in `pyproject.toml`, but it does not run uv. That allowed the 4.2.1 release PR to retain 4.2.0 root-package metadata in `uv.lock`. This change makes lockfile synchronization part of the release workflow and adds an independent guard for all pull requests.

## Changes

- Read the generated release PR branch from Release Please’s `pr` output.
- Check out that branch, install a pinned uv version, run `uv lock`, verify the result, and commit only `uv.lock` when it changed.
- Fail closed if lock generation unexpectedly changes any other tracked file.
- Add `Validate uv Lockfile`, scoped to PRs that change `pyproject.toml`, `uv.lock`, or the validation workflow itself.
- Add ten-minute job timeouts and update repository/release documentation.

## How to Test

- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12`
- `uv lock --check`
- `uv run pytest` (887 passed, 10 skipped)
- `uv run ruff check .`
- `uv run pyright`
- `uv run agentrules snapshot sync`
- `uv run python -c 'import agentrules; from importlib.metadata import version; assert version("agentrules") == "4.2.1"'`\n\n## Rollout / Backout\n\n- Rollout requires no migration or new secret; it reuses the existing `RELEASE_PLEASE_TOKEN` / `GITHUB_TOKEN` policy.\n- Back out by reverting this PR. Release Please behavior then returns to its previous state.\n\n## Risks / Notes\n\n- Low risk: the release job stages only `uv.lock`, and it aborts if uv modifies another tracked file.\n- `setup-uv` is pinned to the v8.3.2 commit SHA and uv is pinned to 0.9.17 for deterministic lock generation.\n- No runtime application behavior or public API changes.\n\n## Checklist\n\n- [x] Workflow lint passes\n- [x] Full test suite passes\n- [x] Ruff and Pyright pass\n- [x] Release documentation updated\n- [x] Snapshot sync checked (no update required)